### PR TITLE
Indicates duplicates and prioritizes features/action items

### DIFF
--- a/pkg/notes/document.go
+++ b/pkg/notes/document.go
@@ -34,18 +34,21 @@ func CreateDocument(notes []*ReleaseNote) (*Document, error) {
 		if note.ActionRequired {
 			categorized = true
 			doc.ActionRequired = append(doc.ActionRequired, note.Markdown)
-		}
-
-		for _, sig := range note.SIGs {
+		} else if note.Feature {
 			categorized = true
-			notesForSIG, ok := doc.SIGs[sig]
-			if ok {
-				doc.SIGs[sig] = append(notesForSIG, note.Markdown)
-			} else {
-				doc.SIGs[sig] = []string{note.Markdown}
+			doc.NewFeatures = append(doc.NewFeatures, note.Markdown)
+
+		} else {
+			for _, sig := range note.SIGs {
+				categorized = true
+				notesForSIG, ok := doc.SIGs[sig]
+				if ok {
+					doc.SIGs[sig] = append(notesForSIG, note.Markdown)
+				} else {
+					doc.SIGs[sig] = []string{note.Markdown}
+				}
 			}
 		}
-
 		isBug := false
 		for _, kind := range note.Kinds {
 			switch kind {
@@ -55,8 +58,7 @@ func CreateDocument(notes []*ReleaseNote) (*Document, error) {
 				// kinds and determined that it has no other categorization label.
 				isBug = true
 			case "feature":
-				categorized = true
-				doc.NewFeatures = append(doc.NewFeatures, note.Markdown)
+				continue
 			case "api-change", "new-api":
 				categorized = true
 				doc.APIChanges = append(doc.APIChanges, note.Markdown)


### PR DESCRIPTION
POC, implements suggestions from #3 

Example output:
```
# Action Required

- The --storage-versions flag of kube-apiserver is deprecated. Please omit this flag to ensure the default storage versions are used. Otherwise the cluster is not safe to upgrade to a version newer than 1.12. This flag will be removed in 1.13. ([#68080](https://github.com/kubernetes/kubernetes/pull/68080), [@caesarxuchao](https://github.com/caesarxuchao)) Courtesy of: api-machinery


## New Features

- Registers volume topology information reported by a node-level Container Storage Interface (CSI) driver. This enables Kubernetes support of CSI topology mechanisms. ([#67684](https://github.com/kubernetes/kubernetes/pull/67684), [@verult](https://github.com/verult)) Courtesy of: api-machinery, node, storage, testing
- Bump addon-manager to v8.7 ([#68299](https://github.com/kubernetes/kubernetes/pull/68299), [@MrHohn](https://github.com/MrHohn)) Courtesy of: cluster-lifecycle, testing
- CSI volume plugin does not need external attacher for non-attachable CSI volumes. ([#67955](https://github.com/kubernetes/kubernetes/pull/67955), [@jsafrane](https://github.com/jsafrane)) Courtesy of: api-machinery, node, storage, testing
- KubeletPluginsWatcher feature graduates to beta. ([#68200](https://github.com/kubernetes/kubernetes/pull/68200), [@RenaudWasTaken](https://github.com/RenaudWasTaken)) Courtesy of: node, storage, testing
- Add a TTL machenism to clean up Jobs after they finish. ([#66840](https://github.com/kubernetes/kubernetes/pull/66840), [@janetkuo](https://github.com/janetkuo)) Courtesy of: api-machinery, apps, architecture, testing
- Not split nodes when searching for nodes but doing it all at once. ([#67555](https://github.com/kubernetes/kubernetes/pull/67555), [@wgliang](https://github.com/wgliang)) Courtesy of: api-machinery, scheduling


## API Changes

- Add a TTL machenism to clean up Jobs after they finish. ([#66840](https://github.com/kubernetes/kubernetes/pull/66840), [@janetkuo](https://github.com/janetkuo)) Courtesy of: api-machinery, apps, architecture, testing


## SIG API Machinery

- kube-controller-manager: use informer cache instead of active pod gets in HPA controller ([#68241](https://github.com/kubernetes/kubernetes/pull/68241), [@krzysztof-jastrzebski](https://github.com/krzysztof-jastrzebski)) <DUPLICATE> KEEP | REMOVE ? appears in: api-machinery, autoscaling
- CSI NodePublish call can optionally contain information about the pod that requested the CSI volume. ([#67945](https://github.com/kubernetes/kubernetes/pull/67945), [@jsafrane](https://github.com/jsafrane)) <DUPLICATE> KEEP | REMOVE ? appears in: api-machinery, node, storage, testing


## SIG Apps

- If `TaintNodesByCondition` is enabled, add `node.kubernetes.io/unschedulable` and ([#64954](https://github.com/kubernetes/kubernetes/pull/64954), [@k82cn](https://github.com/k82cn)) <DUPLICATE> KEEP | REMOVE ? appears in: apps, scheduling, testing
- Let service controller retry creating load balancer when persistUpdate failed due to conflict. ([#68087](https://github.com/kubernetes/kubernetes/pull/68087), [@grayluck](https://github.com/grayluck))


## SIG Autoscaling

- kube-controller-manager: use informer cache instead of active pod gets in HPA controller ([#68241](https://github.com/kubernetes/kubernetes/pull/68241), [@krzysztof-jastrzebski](https://github.com/krzysztof-jastrzebski)) <DUPLICATE> KEEP | REMOVE ? appears in: api-machinery, autoscaling

```
WDYT? @marpaia @nickchase