### PR TITLE
Disables duplication to kind/api-changes, kind/bug headings and adds Duplicate Notes Heading

### DIFF
--- a/pkg/notes/document.go
+++ b/pkg/notes/document.go
@@ -48,34 +48,33 @@ func CreateDocument(notes []*ReleaseNote) (*Document, error) {
 					doc.SIGs[sig] = []string{note.Markdown}
 				}
 			}
-		}
-		isBug := false
-		for _, kind := range note.Kinds {
-			switch kind {
-			case "bug":
-				// if the PR has kind/bug, we want to make a note of it, but we don't
-				// include it in the Bug Fixes section until we haven't processed all
-				// kinds and determined that it has no other categorization label.
-				isBug = true
-			case "feature":
-				continue
-			case "api-change", "new-api":
-				categorized = true
-				doc.APIChanges = append(doc.APIChanges, note.Markdown)
+			isBug := false
+			for _, kind := range note.Kinds {
+				switch kind {
+				case "bug":
+					// if the PR has kind/bug, we want to make a note of it, but we don't
+					// include it in the Bug Fixes section until we haven't processed all
+					// kinds and determined that it has no other categorization label.
+					isBug = true
+				case "feature":
+					continue
+				case "api-change", "new-api":
+					categorized = true
+					doc.APIChanges = append(doc.APIChanges, note.Markdown)
+				}
 			}
-		}
 
-		// if the note has not been categorized so far, we can toss in one of two
-		// buckets
-		if !categorized {
-			if isBug {
-				doc.BugFixes = append(doc.BugFixes, note.Markdown)
-			} else {
-				doc.Uncategorized = append(doc.Uncategorized, note.Markdown)
+			// if the note has not been categorized so far, we can toss in one of two
+			// buckets
+			if !categorized {
+				if isBug {
+					doc.BugFixes = append(doc.BugFixes, note.Markdown)
+				} else {
+					doc.Uncategorized = append(doc.Uncategorized, note.Markdown)
+				}
 			}
 		}
 	}
-
 	return doc, nil
 }
 

--- a/pkg/notes/document.go
+++ b/pkg/notes/document.go
@@ -8,6 +8,7 @@ import (
 
 // Document represents the underlying structure of a release notes document.
 type Document struct {
+	Duplicates     []string            `json:"duplicate_notes"`
 	NewFeatures    []string            `json:"new_features"`
 	ActionRequired []string            `json:"action_required"`
 	APIChanges     []string            `json:"api_changes"`
@@ -20,6 +21,7 @@ type Document struct {
 // release notes
 func CreateDocument(notes []*ReleaseNote) (*Document, error) {
 	doc := &Document{
+		Duplicates:     []string{},
 		NewFeatures:    []string{},
 		ActionRequired: []string{},
 		APIChanges:     []string{},
@@ -37,7 +39,9 @@ func CreateDocument(notes []*ReleaseNote) (*Document, error) {
 		} else if note.Feature {
 			categorized = true
 			doc.NewFeatures = append(doc.NewFeatures, note.Markdown)
-
+		} else if note.Duplicate {
+			categorized = true
+			doc.Duplicates = append(doc.Duplicates, note.Markdown)
 		} else {
 			for _, sig := range note.SIGs {
 				categorized = true
@@ -110,6 +114,15 @@ func RenderMarkdown(doc *Document, w io.Writer) error {
 			s = "- " + s
 		}
 		write(s + "\n")
+	}
+
+	// the "Duplicate Notes" section
+	if len(doc.Duplicates) > 0 {
+		write("## Duplicated Notes\n\n")
+		for _, note := range doc.Duplicates {
+			writeNote(note)
+		}
+		write("\n\n")
 	}
 
 	// the "Action Required" section

--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -64,6 +64,9 @@ type ReleaseNote struct {
 	// Indicates whether or not a note will appear as a new feature
 	Feature bool `json:"feature,omitempty"`
 
+	// Indicates whether or not a note is duplicated across SIGs
+	Duplicate bool `json:"duplicate,omitempty"`
+
 	// ActionRequired indicates whether or not the release-note-action-required
 	// label was set on the PR
 	ActionRequired bool `json:"action_required,omitempty"`
@@ -179,6 +182,7 @@ func ReleaseNoteFromCommit(commit *github.RepositoryCommit, client *github.Clien
 	authorUrl := fmt.Sprintf("https://github.com/%s", author)
 	prUrl := fmt.Sprintf("https://github.com/kubernetes/kubernetes/pull/%d", pr.GetNumber())
 	IsFeature := HasString(LabelsWithPrefix(pr, "kind"), "feature")
+	IsDuplicate := false
 	sigsListPretty := ""
 	noteSuffix := ""
 
@@ -203,7 +207,8 @@ func ReleaseNoteFromCommit(commit *github.RepositoryCommit, client *github.Clien
 		}
 	} else if len(LabelsWithPrefix(pr, "sig")) > 1 {
 		if sigsListPretty != "" {
-			noteSuffix = fmt.Sprintf("<DUPLICATE> KEEP | REMOVE ? also appears in: %s", sigsListPretty)
+			noteSuffix = fmt.Sprintf("<DUPLICATED> Appears in: %s", sigsListPretty)
+			IsDuplicate = true
 
 		}
 	}
@@ -225,6 +230,7 @@ func ReleaseNoteFromCommit(commit *github.RepositoryCommit, client *github.Clien
 		Kinds:          LabelsWithPrefix(pr, "kind"),
 		Areas:          LabelsWithPrefix(pr, "area"),
 		Feature:        IsFeature,
+		Duplicate:      IsDuplicate,
 		ActionRequired: IsActionRequired(pr),
 	}, nil
 }


### PR DESCRIPTION
Currently notes labelled `kind/api-change`, `kind/new-api` and `kind/bug` can be duplicated in "New-Features" or "Action-Required" which seems undesirable. This PR will correct this behaviour to make each of these headings exclusive to each of these labels with "Action Required" and "New Feature" taking precedence.

Currently Duplicate notes are sorted into the heading for each SIG that they are duplicated across. This PR changes that behaviour by sorting all duplicated notes into a common "Duplicate Notes" heading in an attempt to increase readability for sig-leads.
