### PR TITLE
Include SIG headers in the duplicate notes section

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -183,34 +183,15 @@ func ReleaseNoteFromCommit(commit *github.RepositoryCommit, client *github.Clien
 	prUrl := fmt.Sprintf("https://github.com/kubernetes/kubernetes/pull/%d", pr.GetNumber())
 	IsFeature := HasString(LabelsWithPrefix(pr, "kind"), "feature")
 	IsDuplicate := false
-	sigsListPretty := ""
+	sigsListPretty := prettifySigList(LabelsWithPrefix(pr, "sig"))
 	noteSuffix := ""
-
-	sigLabels := LabelsWithPrefix(pr, "sig")
-	sigs := make([]string, len(sigLabels))
-	for i, sig := range LabelsWithPrefix(pr, "sig") {
-		sigs[i] = fmt.Sprintf("SIG %s", prettySIG(sig))
-
-		if i == 0 {
-			sigsListPretty = fmt.Sprintf("SIG %s", prettySIG(sig))
-		} else if i == (len(sigLabels) - 1) {
-			sigsListPretty = fmt.Sprintf("%s, and SIG %s", sigsListPretty, prettySIG(sig))
-		} else {
-			sigsListPretty = fmt.Sprintf("%s, SIG %s", sigsListPretty, prettySIG(sig))
-		}
-	}
 
 	if IsActionRequired(pr) || IsFeature {
 		if sigsListPretty != "" {
 			noteSuffix = fmt.Sprintf("Courtesy of %s", sigsListPretty)
-
 		}
 	} else if len(LabelsWithPrefix(pr, "sig")) > 1 {
-		if sigsListPretty != "" {
-			noteSuffix = fmt.Sprintf("<DUPLICATED> Appears in: %s", sigsListPretty)
-			IsDuplicate = true
-
-		}
+		IsDuplicate = true
 	}
 	markdown := fmt.Sprintf("%s ([#%d](%s), [@%s](%s))", text, pr.GetNumber(), prUrl, author, authorUrl)
 


### PR DESCRIPTION
Consider the output from the following command:

```
./release-notes -start-sha=ad2ed0e7dfe1ac914e6d1ecd369d57111fd365c6 -end-sha=94e59f1636a8f8b1566ef35180519d4de5586b79
```

## New Features

- Registers volume topology information reported by a node-level Container Storage Interface (CSI) driver. This enables Kubernetes support of CSI topology mechanisms. ([#67684](https://github.com/kubernetes/kubernetes/pull/67684), [@verult](https://github.com/verult)) Courtesy of SIG API Machinery, SIG Node, SIG Storage, and SIG Testing
- Bump addon-manager to v8.7 ([#68299](https://github.com/kubernetes/kubernetes/pull/68299), [@MrHohn](https://github.com/MrHohn)) Courtesy of SIG Cluster Lifecycle, and SIG Testing


## Notes From Multiple SIGs

### SIG API Machinery, and SIG Autoscaling

- kube-controller-manager: use informer cache instead of active pod gets in HPA controller ([#68241](https://github.com/kubernetes/kubernetes/pull/68241), [@krzysztof-jastrzebski](https://github.com/krzysztof-jastrzebski))

### SIG Azure, and SIG Cloud Provider

- Support NodeShutdown taint for azure ([#68033](https://github.com/kubernetes/kubernetes/pull/68033), [@yastij](https://github.com/yastij))

### SIG Apps, SIG Scheduling, and SIG Testing

- If `TaintNodesByCondition` is enabled, add `node.kubernetes.io/unschedulable` and `node.kubernetes.io/network-unavailable` automatically to DaemonSet pods. ([#64954](https://github.com/kubernetes/kubernetes/pull/64954), [@k82cn](https://github.com/k82cn))


## Notes from Individual SIGs

### SIG Apps

- Let service controller retry creating load balancer when persistUpdate failed due to conflict. ([#68087](https://github.com/kubernetes/kubernetes/pull/68087), [@grayluck](https://github.com/grayluck))

### SIG Cloud Provider

- Deprecate cloudstack and ovirt controllers ([#68199](https://github.com/kubernetes/kubernetes/pull/68199), [@dims](https://github.com/dims))

### SIG Cluster Lifecycle

- kubeadm: added phase command "alpha phase kubelet config annotate-cri" ([#68449](https://github.com/kubernetes/kubernetes/pull/68449), [@fabriziopandini](https://github.com/fabriziopandini))
- External CAs can now be used for kubeadm with only a certificate, as long as all required certificates already exist. ([#68296](https://github.com/kubernetes/kubernetes/pull/68296), [@liztio](https://github.com/liztio))

### SIG Node

- add missing LastTransitionTime of ContainerReady condition ([#64867](https://github.com/kubernetes/kubernetes/pull/64867), [@dixudx](https://github.com/dixudx))



