### PR TITLE
Various bug fixes due to recent changes is CI tooling

### DIFF
--- a/pkg/notes/notes.go
+++ b/pkg/notes/notes.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/google/go-github/github"
@@ -191,7 +190,6 @@ func NoteTextFromString(s string) (string, error) {
 		return note, nil
 	}
 
-	spew.Dump(s)
 	return "", errors.New("no matches found when parsing note text from commit string")
 }
 
@@ -359,9 +357,7 @@ func ListCommitsWithNotes(
 		// Similarly, now that the known not-release-notes are filtered out, we can
 		// use some patterns to find actual release notes.
 		inclusionFilters := []string{
-			"```release-note",
 			"release-note",
-			"```dev-release-note",
 			"Does this PR introduce a user-facing change?",
 		}
 

--- a/pkg/notes/notes_test.go
+++ b/pkg/notes/notes_test.go
@@ -2,6 +2,7 @@ package notes
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -100,5 +101,24 @@ func TestStripStar(t *testing.T) {
 
 	for _, note := range notes {
 		require.Equal(t, "The note text", stripStar(note))
+	}
+}
+
+func TestReleaseNoteParsing(t *testing.T) {
+	client := githubClient(t)
+	commitsWithNote := []string{
+		"5f750c593f94027896d683d32cf86cfbb2c8ce7e",
+		"26083c3d0934caef6f44978384b96a6315fff875",
+		"c585d13e36f4f8f7368ba35cef27fca271bc7083",
+		"1355e6b27713bbbdd3e5975e6fa815368f205c5d",
+	}
+	ctx := context.Background()
+
+	for _, sha := range commitsWithNote {
+		fmt.Println(sha)
+		commit, _, err := client.Repositories.GetCommit(ctx, "kubernetes", "kubernetes", sha)
+		require.NoError(t, err)
+		_, err = ReleaseNoteFromCommit(commit, client)
+		require.NoError(t, err)
 	}
 }


### PR DESCRIPTION
A few things changed recently which caused the tool to stop working properly:

- Release notes are no longer included by the merge bot in the actual commit to master
  - The text from the PR description was used as the final text (allowing developers to edit their notes after merge), but the fact that the merge bot was doing this was used to determine whether or not a commit was merged by a PR which contained a release note
- Commits are now merged by a user called `k8s-ci-robot` instead of `k8s-merge-bot`